### PR TITLE
ci: build & push api/web images to GHCR

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -1,0 +1,81 @@
+name: Build & Push images (GHCR)
+
+# Builds the OctoCounts backend (api) and frontend (web) images and pushes
+# them to GitHub Container Registry. The infra repo pulls these by tag.
+#
+# Triggers:
+#   - push a version tag (v1.2.3)  -> images tagged :v1.2.3 and :latest
+#   - push to main                 -> images tagged :main and :sha-xxxxxxx
+#   - manual dispatch              -> images tagged :manual and :sha-xxxxxxx
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      vite_api_base:
+        description: "VITE_API_BASE baked into the frontend build"
+        default: "/api"
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  # images: ghcr.io/<owner>/octocounts-api , ghcr.io/<owner>/octocounts-web
+  IMAGE_API: ${{ github.repository_owner }}/octocounts-api
+  IMAGE_WEB: ${{ github.repository_owner }}/octocounts-web
+  VITE_API_BASE: ${{ github.event.inputs.vite_api_base || '/api' }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: api
+            context: ./backend
+            image_var: IMAGE_API
+            build_args: ""
+          - name: web
+            context: ./frontend
+            image_var: IMAGE_WEB
+            build_args: |
+              VITE_API_BASE=${{ github.event.inputs.vite_api_base || '/api' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker metadata (tags/labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env[matrix.image_var] }}
+          tags: |
+            type=ref,event=tag
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=raw,value=main,enable=${{ github.ref == 'refs/heads/main' }}
+            type=sha,prefix=sha-,format=short
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build & push ${{ matrix.name }}
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.context }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: ${{ matrix.build_args }}
+          cache-from: type=gha,scope=${{ matrix.name }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.name }}

--- a/how-to-run-and-deploy.md
+++ b/how-to-run-and-deploy.md
@@ -153,20 +153,29 @@ The release workflow attaches both packages to the tag's GitHub Release. Chrome 
 
 ## Production Deployment
 
-Tested on a plain VPS. No Kubernetes required, no Helm charts, no regrets.
+Production is **not** built on the server. CI builds the images and the private
+infra repo deploys them.
 
-```bash
-cp .env.example .env
-# Edit .env — at minimum set DATABASE_URL to Neon/Postgres and set GITHUB_TOKEN
-docker compose up --build -d
-```
+**1. Images — built by CI, pushed to GHCR.**
+`.github/workflows/build-images.yml` builds the backend and frontend on every push
+to `main` and on `v*` tags, publishing:
 
-Services expose:
-
-| Service | Address |
+| Image | Contents |
 |---|---|
-| API | `http://SERVER_IP:8080` |
-| Frontend | `http://SERVER_IP:5173` |
+| `ghcr.io/huanglizhuo/octocounts-api` | backend (`backend/`) |
+| `ghcr.io/huanglizhuo/octocounts-web` | frontend (`frontend/`) |
+
+Cut a release by pushing a version tag (`git tag v0.4.0 && git push origin v0.4.0`),
+which also tags the images `:v0.4.0` and `:latest`.
+
+**2. Deploy — from the private `sloc-infra` repo.**
+The running stack (Caddy + Cloudflare Tunnel + this API, and the librivox service)
+lives in `huanglizhuo/sloc-infra`. It pulls the pinned GHCR images — no `docker build`
+on the box. To ship a new version: push a tag here, then bump `OCTO_TAG` in
+`sloc-infra/secrets/prod.env` and run `make deploy`. Roll back by setting the tag back.
+
+> The old `docker compose up --build -d` flow (build-on-server) is superseded by the
+> above. `docker-compose.dev.yml` remains for local development.
 
 ### Environment variables
 


### PR DESCRIPTION
Adds a workflow that builds the OctoCounts backend (`octocounts-api`) and frontend (`octocounts-web`) and pushes them to GHCR on tags/main/dispatch, so the infra repo (`sloc-infra`) deploys pinned images instead of building on the server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)