### PR TITLE
test(backend): drop the GitLab row from the sitemap golden fixture

### DIFF
--- a/backend/src/golden.rs
+++ b/backend/src/golden.rs
@@ -388,6 +388,14 @@ async fn seo_monoliths_matches_golden() {
     harness.drop_schema().await;
 }
 
+/// Three URLs for four seeded repositories: the GitLab row is absent on
+/// purpose. `seo::sitemap` filters to `RepositoryProvider::GitHub` because the
+/// edge function only ever builds `/github/*` paths, so publishing a
+/// `/gitlab/*` URL would put a 404 in the sitemap. Do not restore that entry to
+/// make the counts look symmetrical — the seed keeps a GitLab report precisely
+/// so this fixture proves the filter fires, and its reappearance means either
+/// the filter was dropped or a GitLab route now exists and the comment in
+/// `seo.rs` needs retiring with it.
 #[tokio::test]
 async fn seo_sitemap_matches_golden() {
     let Some(harness) = harness().await else {

--- a/backend/src/testdata/seo_sitemap.json
+++ b/backend/src/testdata/seo_sitemap.json
@@ -4,10 +4,6 @@
     "loc": "https://octocounts.com/github/octocounts/empty"
   },
   {
-    "lastmod": "2024-05-20",
-    "loc": "https://octocounts.com/gitlab/gitlab-org/ci-cd/gitlab-runner"
-  },
-  {
     "lastmod": "2024-03-14",
     "loc": "https://octocounts.com/github/rust-lang/rust"
   },


### PR DESCRIPTION
`golden::seo_sitemap_matches_golden` is red on `main`. The fixture is the stale side, not the code.

## What happened

`/api/seo/sitemap` has filtered to GitHub reports since 8664315 (2026-08-19) — the Pages function only builds `/github/*` paths, so a `/gitlab/*` entry in the sitemap would publish a 404. `backend/src/testdata/seo_sitemap.json` was pinned in bd0a40c (2026-08-04) and still carries the `gitlab-org/ci-cd/gitlab-runner` row.

The diff was invisible rather than ignored. Every test that reads these fixtures starts with

```rust
let Some(harness) = harness().await else { return; };
```

so without `TEST_DATABASE_URL` they pass by doing nothing, and `cargo test` prints the same summary either way.

## Reproduce

```bash
docker run -d --name octocounts-test-db \
  -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=octocounts_test \
  -p 55432:5432 postgres:17

TEST_DATABASE_URL=postgres://postgres:postgres@127.0.0.1:55432/octocounts_test \
  cargo test --manifest-path backend/Cargo.toml golden::seo_sitemap
```

On `main`:

```
thread 'golden::seo_sitemap_matches_golden' panicked at src/golden.rs:343:5:
assertion `left == right` failed: response drifted from backend/src/testdata/seo_sitemap.json
  left:  3 entries, all /github/*
  right: 4 entries, including "https://octocounts.com/gitlab/gitlab-org/ci-cd/gitlab-runner"

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 157 filtered out
```

On this branch, the whole `golden` module:

```
test golden::seo_sitemap_matches_golden ... ok
test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 145 filtered out
```

## Why the fixture moves and not the filter

The filter is current and commented in `seo.rs`, and the seed deliberately keeps its GitLab report — so the three-row fixture is what proves the filter fires. I added a comment on the test saying that, because a fixture listing three URLs for four seeded repositories otherwise reads like an omission worth "fixing", and the next person to notice would restore the row and turn the test green against a response the code no longer produces.
