### PR TITLE
fix(frontend): only warn about GitHub when GitHub says so

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,8 @@
     "dev": "vite --host 127.0.0.1",
     "build": "tsc && vite build",
     "test:seo": "npm run build && node --test tests/seo.test.mjs",
+    "test:unit": "node --test tests/github-status.test.mjs",
+    "test": "npm run test:unit && npm run test:seo",
     "preview": "vite preview --host 127.0.0.1"
   },
   "dependencies": {

--- a/frontend/src/githubStatus.ts
+++ b/frontend/src/githubStatus.ts
@@ -42,6 +42,36 @@ export function fetchGithubStatus(): Promise<HostStatus | null> {
   return inflight;
 }
 
+// Statuspage's aggregate `indicator` vocabulary, of which "none" is the
+// healthy value. Kept as data next to the predicate below so that the one
+// place in this codebase that knows GitHub's status vocabulary is also the one
+// place that decides what it means.
+const DEGRADED_INDICATORS = new Set(["minor", "major", "critical", "maintenance"]);
+
+/**
+ * Whether the repository host is reporting trouble, i.e. whether a "this may
+ * fail" hint is honest.
+ *
+ * The healthy `indicator` is "none", *not* "operational" — "All Systems
+ * Operational" is the human-readable `description` beside it. Mistaking one
+ * for the other is not hypothetical: both call sites shipped
+ * `indicator !== "operational"`, which is true precisely when GitHub is
+ * healthy, so the homepage showed every visitor "All Systems Operational —
+ * analyses may fail until it recovers" on every load, and the error path's
+ * "status page reports normal operation" copy was unreachable except when the
+ * fetch itself failed.
+ *
+ * An unrecognised indicator counts as healthy, deliberately. This is
+ * supplementary context and never a dependency of the analysis flow (see
+ * `fetchGithubStatus`), so failing quiet costs a missing hint during an
+ * outage, while failing loud costs a permanent scare line under the hero —
+ * which is the bug this function exists to prevent, not to re-enact under a
+ * new spelling.
+ */
+export function isHostDegraded(status: HostStatus | null): status is HostStatus {
+  return status !== null && DEGRADED_INDICATORS.has(status.indicator);
+}
+
 /** Live host status for components; re-renders once the fetch settles. */
 export function useGithubStatus(): HostStatus | null {
   const [status, setStatus] = useState<HostStatus | null>(() => cache?.value ?? null);

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -6,7 +6,7 @@ import i18n, { ready as i18nReady } from "./i18n";
 import { ChromeIcon, EdgeIcon, FirefoxIcon } from "./icons";
 import { defaultRepoUrl, defaultRefName, extensionInfo } from "./constants";
 import { analyzeRepository, fetchGrowthStats, fetchJson } from "./api";
-import { useGithubStatus } from "./githubStatus";
+import { isHostDegraded, useGithubStatus } from "./githubStatus";
 import { AnalyticsEvents, initAnalytics, providerFromRepoUrl, trackAiVisitIfReferred, trackEvent } from "./analytics";
 import { Topbar, publicReportLinks } from "./Topbar";
 
@@ -344,7 +344,7 @@ function App() {
             <p className="subtitle">
               <Trans i18nKey="hero.subtitle" components={{ 1: <a href="https://github.com/XAMPPRocky/tokei" target="_blank" rel="noreferrer" /> }} />
             </p>
-            {hostStatus && hostStatus.indicator !== "operational" ? (
+            {isHostDegraded(hostStatus) ? (
               <p className="host-status-hint" role="status">
                 {hostStatus.description} — {t("githubStatus.degradedHint")}{" "}
                 <a href="https://www.githubstatus.com" target="_blank" rel="noreferrer">{t("githubStatus.link")}</a>
@@ -1038,7 +1038,7 @@ function ErrorState({ code, message, onRetry }: { code?: string; message: string
         <p>{t(helpKey)}</p>
         {code === "github_unavailable" ? (
           <p className="host-status-line">
-            {hostStatus && hostStatus.indicator !== "operational"
+            {isHostDegraded(hostStatus)
               ? `${t("githubStatus.official")} ${hostStatus.description} `
               : `${t("githubStatus.officialOperational")} `}
             <a href="https://www.githubstatus.com" target="_blank" rel="noreferrer">{t("githubStatus.link")}</a>

--- a/frontend/tests/github-status.test.mjs
+++ b/frontend/tests/github-status.test.mjs
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import test from "node:test";
+import ts from "typescript";
+
+// seo.test.mjs imports its transpiled module from a data: URL, which works
+// there because colorContrast.ts imports nothing. githubStatus.ts imports React
+// for its hook, and a data: URL has no parent directory to resolve a bare
+// specifier from, so the compiled copy is written under node_modules/ instead:
+// somewhere "react" resolves from, and somewhere git already ignores.
+const cacheDir = new URL("../node_modules/.cache/octocounts-tests/", import.meta.url);
+const source = await readFile(new URL("../src/githubStatus.ts", import.meta.url), "utf8");
+const compiled = ts.transpileModule(source, {
+  compilerOptions: { module: ts.ModuleKind.ESNext, target: ts.ScriptTarget.ES2020 },
+});
+await mkdir(cacheDir, { recursive: true });
+const modulePath = new URL("github-status.mjs", cacheDir);
+await writeFile(modulePath, compiled.outputText);
+const { isHostDegraded } = await import(modulePath.href);
+
+// The exact payload https://www.githubstatus.com/api/v2/status.json serves when
+// nothing is wrong. The pairing is the trap this file exists for: the indicator
+// says "none" while the description says "All Systems Operational", and the
+// shipped bug was a comparison against the word from the description.
+const HEALTHY = { indicator: "none", description: "All Systems Operational" };
+
+test("GitHub's healthy payload is not degraded", () => {
+  assert.equal(isHostDegraded(HEALTHY), false);
+});
+
+test('"operational" is not a statuspage indicator', () => {
+  // If this ever asserts true, the homepage is back to telling every visitor
+  // that analyses may fail while quoting "All Systems Operational" at them.
+  assert.notEqual(HEALTHY.indicator, "operational");
+  assert.equal(isHostDegraded({ indicator: "operational", description: "All Systems Operational" }), false);
+});
+
+test("real outage indicators are degraded", () => {
+  for (const indicator of ["minor", "major", "critical", "maintenance"]) {
+    assert.equal(isHostDegraded({ indicator, description: "Partial outage" }), true, indicator);
+  }
+});
+
+test("an absent or unrecognised status is treated as healthy", () => {
+  // Deliberate: the hint is supplementary, so a renamed indicator should cost a
+  // missing warning during an outage rather than a permanent one at all times.
+  assert.equal(isHostDegraded(null), false);
+  assert.equal(isHostDegraded({ indicator: "", description: "" }), false);
+  assert.equal(isHostDegraded({ indicator: "some_future_indicator", description: "?" }), false);
+});


### PR DESCRIPTION
Every visitor to octocounts.com currently reads this under the hero, on every page load, while GitHub is perfectly healthy:

> All Systems Operational — analyses may fail until it recovers.

## Cause

Both call sites test `indicator !== "operational"`. Statuspage's healthy `indicator` is `"none"`; `"All Systems Operational"` is the `description` beside it. The live payload from `https://www.githubstatus.com/api/v2/status.json`:

```json
{ "status": { "indicator": "none", "description": "All Systems Operational" } }
```

So the comparison is true precisely when GitHub is fine. Two consequences:

- `main.tsx:347` — the hero banner shows on every load, quoting the healthy description as if it were the outage.
- `main.tsx:1041` — the error path's `githubStatus.officialOperational` string ("the status page reports normal operation") was unreachable except when the status fetch itself failed.

## Fix

Both call sites now share `isHostDegraded()`, so the one module that knows GitHub's status vocabulary is also the one place that decides what it means.

An unrecognised indicator counts as healthy, deliberately. This hint is supplementary context and never a dependency of the analysis flow — the same reason `fetchGithubStatus` already swallows its own errors — so failing quiet costs a missing warning during an outage, while failing loud costs a permanent scare line under the hero. Which is this bug, and not something worth re-enacting under a new spelling.

## Tests

`frontend/tests/github-status.test.mjs` — 4 tests. It pins the healthy payload as a *pair*, since that pairing is the whole trap, and asserts that `"operational"` is not a degraded indicator. It transpiles the TS with the `typescript` devDependency already in the tree, the way `tests/seo.test.mjs` does; the compiled copy goes under `node_modules/.cache/` because `githubStatus.ts` imports React and a `data:` URL has no parent directory to resolve a bare specifier from.

Also adds `npm run test:unit`, and `npm test` = unit + seo. Verified on this branch against this repo's own lockfile (vite 6.4.2, no dependency changes):

```
$ npm run test:unit
ℹ tests 4 / ℹ pass 4 / ℹ fail 0

$ npm test
ℹ tests 4 / ℹ pass 4 / ℹ fail 0
ℹ tests 30 / ℹ pass 30 / ℹ fail 0
```
