### PR TITLE
fix(dev): make the compose dev stack serve the site

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -51,6 +51,16 @@ services:
     volumes:
       - ./frontend:/app
       - frontend-node-modules:/app/node_modules
+      # vite.config.ts reads ../extension/package.json at config-load time to
+      # inject the extension version into index.html's JSON-LD, so with only
+      # ./frontend mounted the dev server died on boot with
+      # `ENOENT: /extension/package.json` — `docker compose up` brought up the
+      # API and Postgres and no website at all. Mounted at that absolute path
+      # to mirror `COPY extension/package.json /extension/package.json` in
+      # frontend/Dockerfile: the version is real structured data that
+      # tests/seo.test.mjs asserts is substituted, so the fix is to supply the
+      # file, not to teach the config a fake fallback version.
+      - ./extension/package.json:/extension/package.json:ro
     ports:
       - "5173:5173"
     depends_on:


### PR DESCRIPTION
The quickstart at the top of `how-to-run-and-deploy.md` —

```bash
docker compose -f docker-compose.dev.yml up --build
```
> Open `http://127.0.0.1:5173` and you're done.

— brings up Postgres and the API, and nothing at all on 5173.

## Cause

`frontend/vite.config.ts` reads `../extension/package.json` at config-load time, to inject the extension version into `index.html`. The `web-dev` service mounts only `./frontend`, so that file sits one directory *above* the mount and does not exist in the container. Vite can't load the config, and the container exits 1 before it binds a port:

```
$ docker compose -f docker-compose.dev.yml up -d --no-deps web-dev
$ docker compose -f docker-compose.dev.yml ps -a
web-dev   exited (1)

$ docker compose -f docker-compose.dev.yml logs web-dev
error when starting dev server:
Error: ENOENT: no such file or directory, open '/extension/package.json'
    at readFileSync (node:fs:443:20)
    at file:///app/node_modules/.vite-temp/vite.config.ts.timestamp-....mjs:7:3
    ...
    at async loadConfigFromFile (.../vite/dist/node/chunks/dep-Dq2t6Dq0.js:49291:44)
```

`docker compose up` itself still exits 0, and the other two services come up healthy, so the stack looks fine unless you open a browser.

## Fix

One volume line, mounting the file read-only at the absolute path `frontend/Dockerfile` already uses for the production image:

```dockerfile
COPY extension/package.json /extension/package.json
```

I supplied the real file rather than teaching the config a fallback version: it becomes `softwareVersion` in the page's JSON-LD, and `frontend/tests/seo.test.mjs` asserts it is substituted — so a placeholder would trade a loud boot failure for a wrong number on a live page.

## Verified

Same command, on this branch:

```
$ docker compose -f docker-compose.dev.yml ps -a
web-dev   running

$ docker compose -f docker-compose.dev.yml logs web-dev
  VITE v6.4.2  ready in 80 ms
  ➜  Local:   http://localhost:5173/
```

and the page is really served, with a real version in it:

```
GET http://127.0.0.1:5173/  → 200, 22875 bytes
"__EXTENSION_VERSION__" still present in the HTML: false
"softwareVersion" in the JSON-LD: "0.4.6"
<title>OctoCounts – GitHub SLOC Counter</title>
```

## One thing deliberately left out

HMR still doesn't work in this stack on a macOS or Windows host. A bind mount delivers no filesystem events into a Linux container, so the dev server keeps serving the modules it read at boot: you edit a file, reload, and get the old page, with nothing in the log to say why. The fix is `server.watch.usePolling`, but polling is a permanent syscall loop over every watched file and the default matters — a Linux host gets inotify across the mount natively and shouldn't pay for it — so which way that defaults is a separate change and a separate conversation. Happy to open it as a follow-up if you want it.
