### PR TITLE
fix(frontend): repaint after the lazy zh bundle lands

### DIFF
--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -35,6 +35,24 @@ i18n
       order: ["querystring", "localStorage", "navigator"],
       caches: ["localStorage"],
     },
+    // Without this, switching to Chinese in a running page left the entire UI in
+    // English until something else forced a re-render — in practice, until a
+    // reload. react-i18next re-renders on `languageChanged`, and with the config
+    // below i18next emits that *synchronously* — `resources` is inline and there
+    // is no backend plugin or `partialBundledLanguages`, so `loadResources` has
+    // nothing to await and calls back at once, before the lazy zh chunk above
+    // has resolved. Every `t()` in that render falls back to English. The chunk
+    // then lands and
+    // `addResourceBundle` emits `added` on the resource store, which
+    // react-i18next does not listen to by default, so nothing repaints and the
+    // fallback render is the one the visitor keeps until an unrelated state
+    // change happens to schedule one.
+    //
+    // The first-load path never showed this because main.tsx awaits `ready`
+    // before mounting, so the bundle is already in place by the first render.
+    // Only the in-page switch was broken, which is why it survived: the
+    // language persists to localStorage, so a reload looks correct and hides it.
+    react: { bindI18nStore: "added" },
   });
 
 export default i18n;


### PR DESCRIPTION
## The bug

Click **中文** on a page that is already running and the entire UI stays in
English. Reload and it is correct, which is what has kept this hidden.

The sequence, all of it visible in `frontend/src/i18n/index.ts`:

1. `changeLanguage("zh")` makes i18next emit `languageChanged`. With this config
   that emission is synchronous — `init()` passes `resources` inline and sets
   neither a backend plugin nor `partialBundledLanguages`, so `loadResources` has
   nothing to await and calls back immediately.
2. react-i18next is subscribed to `languageChanged`, so it re-renders **now**.
3. The zh bundle is a lazy chunk (`await import("../locales/zh.json")`), so it
   has not arrived. Every `t()` in that render falls back to English.
4. The chunk lands and `addResourceBundle` fires `added` on the resource store.
   react-i18next does not subscribe to that event by default, so nothing
   schedules another render.

The English render is then what the visitor keeps until some unrelated state
change happens to schedule one — a request finishing, a theme toggle. Nothing on
the page tells them to reload.

## The fix

```ts
react: { bindI18nStore: "added" },
```

One line, the option react-i18next provides for exactly this: subscribe to the
resource store's `added` event so a bundle arriving after `languageChanged`
triggers the repaint.

## Why it shipped

First load was never affected — `main.tsx` awaits the exported `ready` promise
before mounting, so the bundle is in place by the first render. And the language
persists to `localStorage`, so a reload always looks right. Only the in-page
switch was broken, and only until the next unrelated re-render.

## Verification

`frontend/qa/visual-qa.spec.ts` already contains the test that catches this —
test 4, *"language switcher to Chinese renders new strings"*. Against a dev
server it fails on the parent commit at its first assertion,
`expect(bodyText).toContain('分析')`, and passes with this line: 8 of 9 tests
before, 9 of 9 after.

Scope of that run, so it is not read as more than it is: Chromium only, because
`playwright.config.ts` declares a single project; against a dev server, not a
production build.

`npm run build` (which runs `tsc` first) and `npm run test:seo` (30 tests) both
pass on this branch.

## What this does not come with

An automated guard. `playwright.config.ts` has no `webServer` block, so the suite
needs a dev server started by hand and a reachable API for the report the spec
waits on — and no workflow in `.github/workflows/` runs `frontend/qa`. So this
fix is verified but not defended: nothing in CI will catch it regressing.

Wiring that up is a bigger change than this one and I did not fold it in. Happy
to open it separately if it would be useful.
