### PR TITLE
fix(extension): read the ref from the page, not the raw tree path

### DIFF
--- a/extension/src/content/card.js
+++ b/extension/src/content/card.js
@@ -6,7 +6,19 @@ import { mountPanel, unmountPanel } from './panel.js';
 
 const POLL_TIMEOUT_MS = 5 * 60 * 1000;
 const MAX_RETRIES = 4;
-const NON_RETRYABLE = new Set(['too_large', 'private_repo', 'forbidden', 'auth_error']);
+// Retrying cannot change any of these answers, so the four retries below only
+// spend ~15s (1s + 2s + 4s + 8s) producing the same failure a fifth time.
+//
+// `not_found` is deliberately NOT here even though it sounds terminal: the API
+// returns it for the archive download 404ing as well as for a missing
+// repository, and the card only ever runs on a page GitHub has already rendered
+// as a public repo — so on this surface a 404 is far more likely transient than
+// a repository that does not exist. The backend retries 5xx and 429 but never a
+// 404, so the client retry is the only one that case gets.
+const NON_RETRYABLE = new Set([
+  'too_large', 'private_repo', 'forbidden', 'auth_error',
+  'ref_not_found', 'invalid_url',
+]);
 const STAR_SUCCESS_COUNT_KEY = 'starPromptSuccessCount';
 
 const SKEL_WIDTHS  = [78, 60, 70, 52, 65, 74, 58, 68];
@@ -402,6 +414,16 @@ function errorMessage(error) {
     auth_error:   t('error.authError'),
     offline:      t('error.offline'),
     timeout:      t('card.error.timedOut'),
+    // Every code in NON_RETRYABLE needs an entry here, because there is no
+    // second line of defence: `classifyError` in `background/index.js` returns
+    // `{ code, status, detail }` and drops the API's `message`, so the
+    // `error?.message` term below is always `undefined`. An unmapped code
+    // therefore renders as "Analysis failed" — and, being non-retryable, with no
+    // retry button either. No explanation and no action. `ref_not_found` also
+    // covers a repository with no commits, which the API reports under this same
+    // code.
+    ref_not_found: t('error.refNotFound'),
+    invalid_url:   t('error.invalidUrl'),
   };
   return codeMap[error?.code] || error?.message || t('error.unknown');
 }

--- a/extension/src/content/detect.js
+++ b/extension/src/content/detect.js
@@ -94,49 +94,150 @@ export function getRepoVisibility(root = document) {
   return publicSignal ? 'public' : 'unknown';
 }
 
-export function parseRepoInfo() {
-  const route = parseRoute(window.location.pathname);
-  if (!route) return { owner: undefined, repo: undefined, ref: 'HEAD', isFork: false };
+/**
+ * `ref` is `''` when the page does not say which ref it is showing. That means
+ * "let the API use the repository's default branch" — the only honest answer,
+ * and one every consumer already handles (`cacheKey`/`inflightKey` fall back to
+ * `HEAD`, and `analyze()` omits an empty ref from the request).
+ *
+ * It must never be a path. Returning `treePath` — the old fallback — sent
+ * `master/app` as a ref on `/tree/master/app`, which the API rejects with
+ * `ref_not_found`.
+ */
+export function parseRepoInfo(pathname = window.location.pathname, root = document) {
+  const route = parseRoute(pathname);
+  if (!route) return { owner: undefined, repo: undefined, ref: '', isFork: false };
 
   const { owner, repo, treePath } = route;
-  const payload = readEmbeddedPayload(document);
-
-  const embeddedRef = payload?.codeViewRepoRoute?.refInfo?.name?.trim()
-    || payload?.refInfo?.name?.trim()
-    || '';
+  const payload = readEmbeddedPayload(root);
 
   const refEl =
-    document.querySelector('[data-hotkey="w"] .css-truncate-target') ??
-    document.querySelector('summary[data-hotkey="w"] span');
+    root.querySelector('[data-hotkey="w"] .css-truncate-target') ??
+    root.querySelector('summary[data-hotkey="w"] span');
   const buttonRef = refEl?.textContent?.trim() || '';
 
-  const metaRef = document.querySelector(
+  const metaRef = root.querySelector(
     'meta[name="octolytics-dimension-repository_default_branch"]'
-  )?.content;
+  )?.content?.trim() || '';
 
   return {
     owner,
     repo,
-    ref: resolveRefFromPage(treePath, embeddedRef, buttonRef, metaRef),
-    isFork: detectFork(payload),
+    ref: resolveRefFromPage(treePath, refsFromPayload(payload), buttonRef, metaRef),
+    isFork: detectFork(payload, root),
   };
 }
 
-function resolveRefFromPage(treePath, embeddedRef, buttonRef, metaRef) {
-  if (!treePath) return embeddedRef || buttonRef || metaRef || 'HEAD';
+/**
+ * Every ref the embedded payload claims, in precedence order.
+ *
+ * `codeViewRepoRoute` alone was the bug: GitHub keeps `refInfo` under the route
+ * wrapper for the page type being rendered, and on a tree view that is
+ * `codeViewTreeRoute`, not `codeViewRepoRoute`. `codeViewLayoutRoute` carries it
+ * on every code-view page type, which makes it the one to trust first.
+ */
+function refsFromPayload(payload) {
+  if (!payload) return [];
 
-  // GitHub encodes refs with slashes as /tree/feature/name, which is ambiguous
-  // with /tree/<ref>/<folder>. The branch/tag button has the full resolved ref.
-  if (embeddedRef && treePath.startsWith(embeddedRef)) return embeddedRef;
-  if (buttonRef && treePath.startsWith(buttonRef)) return buttonRef;
+  const refs = [];
+  const add = value => {
+    const name = typeof value === 'string' ? value.trim() : '';
+    if (name && !refs.includes(name)) refs.push(name);
+  };
 
-  return treePath || embeddedRef || buttonRef || metaRef || 'HEAD';
+  add(payload.codeViewLayoutRoute?.refInfo?.name);
+  add(payload.codeViewTreeRoute?.refInfo?.name);
+  add(payload.codeViewFileTreeLayoutRoute?.refInfo?.name);
+  add(payload.codeViewRepoRoute?.refInfo?.name);
+  add(payload.refInfo?.name);
+
+  // Bounded structural fallback, same shape as repoCandidatesFromPayload: when
+  // GitHub renames the wrapper again, the ref is still under a `refInfo` key.
+  const visit = (value, depth = 0) => {
+    if (!value || typeof value !== 'object' || depth > 8) return;
+    if (Array.isArray(value)) {
+      for (const item of value.slice(0, 100)) visit(item, depth + 1);
+      return;
+    }
+    for (const [key, child] of Object.entries(value)) {
+      if (key === 'refInfo') add(child?.name);
+      visit(child, depth + 1);
+    }
+  };
+  visit(payload);
+
+  return refs;
+}
+
+function resolveRefFromPage(treePath, payloadRefs, buttonRef, metaRef) {
+  const candidates = [...payloadRefs];
+  if (buttonRef) candidates.push(buttonRef);
+
+  // `/tree/feature/name` and `/tree/<ref>/<folder>` are the same URL shape, so a
+  // multi-segment path cannot resolve itself. A ref the page states and that the
+  // path starts with is the ref being viewed; nothing else can be.
+  if (treePath) {
+    const fromPath = candidates.find(
+      ref => treePath === ref || treePath.startsWith(`${ref}/`)
+    );
+    if (fromPath) return fromPath;
+
+    const expanded = expandedShaFor(treePath, candidates);
+    if (expanded) return expanded;
+
+    // Nothing on the page agrees with the URL. But `parseRoute` only reports a
+    // tree view for `/owner/repo/tree/…`, so a `treePath` with no slash in it is
+    // one segment, and one segment after `tree` can only be a ref: a folder
+    // needs a ref in front of it. The ambiguity this function exists to resolve
+    // is `<ref-with-slash>` versus `<ref>/<folder>`, and that shape has a slash
+    // by definition. So read the path — it is the one thing here that is not a
+    // guess, and it is what the user is looking at.
+    if (!treePath.includes('/')) return treePath;
+
+    // Two or more segments, and the page contradicts all of them: either
+    // mid-navigation, where the payload still names the previous page's ref, or
+    // a payload shape this code no longer understands. `''` means the default
+    // branch (see `parseRepoInfo`), which is wrong whenever the URL names
+    // something else — but every alternative is wrong too, and worse. Guessing
+    // the split (`parts[0]` as the ref) invents a ref GitHub never confirmed;
+    // returning a contradicted payload ref is unstable, changing with
+    // navigation timing. The default branch at least matches what the
+    // repo-home card shows for the same repository. Resolving it properly needs
+    // the ref list, which a content script does not have.
+    return '';
+  }
+
+  return candidates[0] || metaRef;
+}
+
+const ABBREVIATED_SHA = /^[0-9a-f]{7,39}$/;
+const FULL_SHA = /^[0-9a-f]{40}$/;
+
+/**
+ * `/tree/ea91b33` is a real URL shape, but GitHub expands the abbreviation in
+ * the payload, so the page states `ea91b33ca57f…` — which the agreement check
+ * above rejects, since it neither equals `treePath` nor is a `<ref>/` prefix of
+ * it. `/tree/ea91b33` on its own would still be caught by the single-segment rule
+ * in the caller, so the shape that needs this one is `/tree/ea91b33/tokio`:
+ * without it that page falls through to `''` and the card silently reports the
+ * *default branch's* count for a URL pinned to a commit.
+ *
+ * The reverse test has to stay scoped to that one shape: a bare
+ * `candidate.startsWith(treePath)` would resolve `/tree/main` to a branch named
+ * `main-v2`. Only a hex abbreviation expanding to a full SHA qualifies, and the
+ * expansion is what gets returned rather than the abbreviation — it is
+ * unambiguous, and it puts both URL shapes on one cache entry per commit.
+ */
+function expandedShaFor(treePath, candidates) {
+  const first = treePath.split('/')[0];
+  if (!ABBREVIATED_SHA.test(first)) return '';
+  return candidates.find(ref => FULL_SHA.test(ref) && ref.startsWith(first)) || '';
 }
 
 // The skipForks setting fails silently when this returns a wrong answer, so the
 // embedded payload comes first here too — `.fork-flag` and `.pagehead-heading-text`
 // no longer exist on the React repo header.
-function detectFork(payload) {
+function detectFork(payload, root = document) {
   const repo = repoFromPayload(payload);
   if (repo) {
     if (repo.isFork === true || repo.fork === true) return true;
@@ -144,10 +245,10 @@ function detectFork(payload) {
     if (repo.isFork === false || repo.fork === false) return false;
   }
 
-  if (document.querySelector('.fork-flag')) return true;
-  if (document.querySelector('[data-testid="fork-flag"]')) return true;
+  if (root.querySelector('.fork-flag')) return true;
+  if (root.querySelector('[data-testid="fork-flag"]')) return true;
 
-  const header = repoHeader(document);
+  const header = repoHeader(root);
   if (header?.textContent?.includes('forked from')) return true;
 
   return false;

--- a/extension/src/locales/en.json
+++ b/extension/src/locales/en.json
@@ -104,6 +104,8 @@
     "forbidden": "OctoCounts API request was blocked or forbidden.",
     "tooLarge": "Repository exceeds the 2 GB archive size limit",
     "notFound": "Repository not found or is empty",
+    "refNotFound": "The branch this page is showing could not be counted.",
+    "invalidUrl": "This repository address could not be read",
     "authError": "OctoCounts API authorization failed",
     "offline": "No network connection",
     "unknown": "Analysis failed",

--- a/extension/src/locales/es.json
+++ b/extension/src/locales/es.json
@@ -104,6 +104,8 @@
     "forbidden": "La solicitud a la API de OctoCounts fue bloqueada o rechazada.",
     "tooLarge": "El repositorio supera el límite de tamaño de archivo de 2 GB",
     "notFound": "Repositorio no encontrado o vacío",
+    "refNotFound": "No se pudo contar la rama que muestra esta página.",
+    "invalidUrl": "No se pudo leer la dirección de este repositorio",
     "authError": "Error de autorización de la API de OctoCounts",
     "offline": "Sin conexión a la red",
     "unknown": "Error en el análisis",

--- a/extension/src/locales/fr.json
+++ b/extension/src/locales/fr.json
@@ -104,6 +104,8 @@
     "forbidden": "La requête API OctoCounts a été bloquée ou refusée.",
     "tooLarge": "Le dépôt dépasse la limite de taille d'archive de 2 Go",
     "notFound": "Dépôt introuvable ou vide",
+    "refNotFound": "La branche affichée sur cette page n'a pas pu être comptée.",
+    "invalidUrl": "Cette adresse de dépôt n'a pas pu être lue",
     "authError": "Échec de l'autorisation API OctoCounts",
     "offline": "Pas de connexion réseau",
     "unknown": "Échec de l'analyse",

--- a/extension/src/locales/ja.json
+++ b/extension/src/locales/ja.json
@@ -104,6 +104,8 @@
     "forbidden": "OctoCounts APIリクエストがブロックまたは拒否されました。",
     "tooLarge": "リポジトリが2 GBのアーカイブサイズ制限を超えています",
     "notFound": "リポジトリが見つからないか、空です",
+    "refNotFound": "このページが表示しているブランチを集計できませんでした。",
+    "invalidUrl": "このリポジトリのアドレスを読み取れませんでした",
     "authError": "OctoCounts APIの認証に失敗しました",
     "offline": "ネットワーク接続がありません",
     "unknown": "分析に失敗しました",

--- a/extension/src/locales/zh.json
+++ b/extension/src/locales/zh.json
@@ -104,6 +104,8 @@
     "forbidden": "OctoCounts API 请求被阻止或禁止。",
     "tooLarge": "仓库超过 2 GB 归档大小限制",
     "notFound": "仓库未找到或为空",
+    "refNotFound": "无法统计该页面显示的分支。",
+    "invalidUrl": "无法解析该仓库地址",
     "authError": "OctoCounts API 授权失败",
     "offline": "无网络连接",
     "unknown": "分析失败",

--- a/extension/src/shared/api.js
+++ b/extension/src/shared/api.js
@@ -37,7 +37,11 @@ export function analyze(owner, repo, ref, forceRefresh = false) {
     headers,
     body: JSON.stringify({
       repoUrl: `https://github.com/${owner}/${repo}`,
-      refName: ref,
+      // Omitted when the page did not say which ref it is showing, which asks
+      // the API for the repository's default branch. The alternative — sending
+      // whatever the URL happened to contain — is what made every
+      // `/tree/<ref>/<dir>` view fail with `ref_not_found`, on any branch name.
+      refName: ref || undefined,
       forceRefresh,
       source: 'extension',
     }),

--- a/extension/tests/fixtures/README.md
+++ b/extension/tests/fixtures/README.md
@@ -13,6 +13,7 @@ value per run, so a resolver that keys off a literal build hash (the original
 | `github-sidebar-no-languages.html` | Small repo with no Languages section, non-English UI |
 | `github-private-repo.html` | Private repo whose only visibility signal is the embedded payload |
 | `github-non-repo.html` | Two-segment non-repo path with a sidebar-shaped container |
+| `github-tree-view.html` | Real `/tree/<ref>/<dir>` capture: the ref lives under `codeViewLayoutRoute`/`codeViewTreeRoute`, `codeViewRepoRoute` is absent, and there is no default-branch meta tag |
 
 ## Refreshing the live capture
 
@@ -29,3 +30,13 @@ Then take the `[class*="-module__borderGrid"]` subtree, strip `svg`/`img`/
 `data-testid` and `id`, and replace the build hashes with `__HASH`. Keep the
 surrounding `main`/README/file-table scaffolding so the main-content rejection
 stays covered.
+
+## Capturing a payload fixture
+
+`github-private-repo.html` and `github-tree-view.html` keep the
+`react-app.embeddedData` script instead, because what they pin lives in the
+payload rather than in the markup. Same capture command, but the payload is
+trimmed by hand: drop `csrf_tokens`, `uploadToken`, `currentUser` and the long
+`fileTree`/`tree.items` lists — a capture is disposable, a fixture is committed —
+and keep every remaining value verbatim so the shape stays real. Say in the
+fixture's leading comment which keys were dropped and when it was captured.

--- a/extension/tests/fixtures/github-tree-view.html
+++ b/extension/tests/fixtures/github-tree-view.html
@@ -1,0 +1,46 @@
+<!--
+  Real `github.com/git/git/tree/master/builtin` markup, captured 2026-08-24 with
+  the recipe in README.md. `git/git`'s default branch is `master`, which is the
+  whole point of picking it.
+
+  This is the page shape the ref resolver got wrong: `codeViewRepoRoute` — the
+  only wrapper it used to read — does not exist on a tree page. The ref is under
+  `codeViewLayoutRoute` and `codeViewTreeRoute`, and `codeViewFileTreeLayoutRoute`
+  carries no `refInfo` at all. The live page also ships no
+  `octolytics-dimension-repository_default_branch` meta tag, so on this route the
+  embedded payload is the only place a ref can be read from — there is no
+  fallback left to lean on.
+
+  Trimmed, because a capture is disposable and a fixture is committed:
+  `csrf_tokens`, `uploadToken` and `currentUser` are gone, as are the ~140-entry
+  `fileTree`/`tree.items` lists, the Copilot/shortcut feature flags, the avatar
+  URL and the header's SVG and inline-style noise. Nothing that remains was
+  edited — every key and value below is verbatim from the capture, which is the
+  only reason it can testify to anything.
+-->
+<html lang="en">
+<head>
+  <meta name="octolytics-dimension-repository_id" content="36502">
+  <meta name="octolytics-dimension-repository_nwo" content="git/git">
+  <meta name="octolytics-dimension-repository_public" content="true">
+  <meta name="octolytics-dimension-repository_is_fork" content="false">
+  <script type="application/json" data-target="react-app.embeddedData">
+    {"payload":{"codeViewTreeRoute":{"path":"builtin","refInfo":{"name":"master","listCacheKey":"v0:1784844020.0","canEdit":false,"refType":"branch","currentOid":"1a3e64c6c4a623626ff0687008732a8e007e2a1c"},"treeExpanded":true,"symbolsExpanded":false},"codeViewLayoutRoute":{"repo":{"id":36502,"defaultBranch":"master","name":"git","ownerLogin":"git","currentUserCanPush":false,"isFork":false,"isEmpty":false,"createdAt":"2008-07-23T14:21:26.000Z","public":true,"private":false,"isOrgOwned":true},"path":"builtin","refInfo":{"name":"master","listCacheKey":"v0:1784844020.0","canEdit":false,"currentOid":"1a3e64c6c4a623626ff0687008732a8e007e2a1c"},"treeExpanded":true},"codeViewFileTreeLayoutRoute":{"foldersToFetch":[]}}}
+  </script>
+</head>
+<body>
+  <div id="repository-container-header" class="tmp-pt-3 hide-full-screen">
+    <div class="d-flex flex-wrap flex-items-center wb-break-word f3 text-normal">
+      <span class="author flex-self-stretch"><a class="url fn" href="/git">git</a></span>
+      <span class="mx-1 flex-self-stretch color-fg-muted">/</span>
+      <strong class="mr-2 flex-self-stretch"><a href="/git/git">git</a></strong>
+      <span></span><span class="Label Label--secondary v-align-middle mr-1">Public</span>
+    </div>
+  </div>
+  <main>
+    <div id="repo-content-pjax-container">
+      <h2>builtin</h2>
+    </div>
+  </main>
+</body>
+</html>

--- a/extension/tests/github-dom.test.mjs
+++ b/extension/tests/github-dom.test.mjs
@@ -15,7 +15,7 @@ import {
   fingerprintHash,
   LANGUAGE_HEADINGS,
 } from '../src/content/github-dom.js';
-import { getRepoVisibility, isPrivateRepo } from '../src/content/detect.js';
+import { getRepoVisibility, isPrivateRepo, parseRepoInfo } from '../src/content/detect.js';
 
 const FIXTURES = new URL('./fixtures/', import.meta.url);
 
@@ -294,6 +294,188 @@ test('an unrelated public repository in embedded data cannot prove this page is 
   `);
 
   assert.equal(getRepoVisibility(document), 'unknown');
+});
+
+/* ── ref resolution ──────────────────────────────────────────────────────── */
+
+// The anchor for this whole section: real markup, on the exact route that was
+// broken. `github-tree-view.html` is `github.com/git/git/tree/master/builtin`,
+// and the resolver this replaces answered `master/builtin` on it — the tree path,
+// which the API rejects with `ref_not_found`. `git/git` is here because its
+// default branch is `master`; on a `main` repository the bug was invisible.
+test('markup captured from a live tree view reports the branch, not the tree path', async () => {
+  const { document } = await loadFixture('github-tree-view.html');
+
+  assert.equal(parseRepoInfo('/git/git/tree/master/builtin', document).ref, 'master');
+  assert.equal(parseRepoInfo('/git/git/tree/master', document).ref, 'master');
+  assert.equal(parseRepoInfo('/git/git', document).ref, 'master');
+  // The card only mounts on a page it can prove is public, so the same capture
+  // has to survive that gate too.
+  assert.equal(getRepoVisibility(document), 'public');
+  assert.equal(parseRepoInfo('/git/git/tree/master/builtin', document).isFork, false);
+});
+
+// The captured page above covers today's payload. These build payloads inline
+// instead, because the shapes they pin are ones no single live page can show at
+// once: the older wrappers GitHub still serves on unmigrated pages, a wrapper
+// name that does not exist yet, and refs (slashes, abbreviated SHAs) that would
+// each need their own capture of their own repository.
+function pageWithPayload(payload, extraHead = '') {
+  const { document } = parseHTML(`
+    <html><head>
+      ${extraHead}
+      <script type="application/json" data-target="react-app.embeddedData">
+        ${JSON.stringify({ payload })}
+      </script>
+    </head><body><div id="repository-container-header"></div></body></html>
+  `);
+  return document;
+}
+
+test('the ref is read from the older route wrappers too', () => {
+  // `codeViewRepoRoute` is the only wrapper the previous resolver looked at, and
+  // it is absent from the live capture above — but GitHub still serves it on
+  // pages it has not migrated, so it stays in the precedence list.
+  const repoRoute = pageWithPayload({
+    codeViewRepoRoute: { refInfo: { name: 'master' } },
+  });
+  assert.equal(parseRepoInfo('/git/git', repoRoute).ref, 'master');
+  assert.equal(parseRepoInfo('/git/git/tree/master/builtin', repoRoute).ref, 'master');
+
+  // `refInfo` at the payload root, the oldest shape of all.
+  const rootRefInfo = pageWithPayload({ refInfo: { name: 'master' } });
+  assert.equal(parseRepoInfo('/git/git/tree/master/builtin', rootRefInfo).ref, 'master');
+});
+
+test('a ref containing slashes survives, and is preferred over its first segment', () => {
+  const document = pageWithPayload({
+    codeViewTreeRoute: { refInfo: { name: 'release/1.x' } },
+  });
+  assert.equal(parseRepoInfo('/octo/demo/tree/release/1.x', document).ref, 'release/1.x');
+  assert.equal(parseRepoInfo('/octo/demo/tree/release/1.x/src', document).ref, 'release/1.x');
+});
+
+test('a stated ref is only believed at a segment boundary', () => {
+  // The `<ref>/` in the agreement check, and the reason it is not a bare
+  // `startsWith`: `main-v2` begins with `main`, so the previous resolver returned
+  // the page's `main` for a URL that says `main-v2` — a real ref, resolvable, and
+  // the wrong tree, reported with no sign anything went wrong. A payload naming
+  // the ref of the page you just navigated away from is exactly how this arises.
+  const document = pageWithPayload({
+    codeViewLayoutRoute: { refInfo: { name: 'main' } },
+  });
+  assert.equal(parseRepoInfo('/octo/demo/tree/main-v2', document).ref, 'main-v2');
+
+  // With a folder after it the URL is ambiguous again and nothing on the page
+  // agrees, so the answer is `''` — the default branch. Still not `main-v2`, but
+  // no longer a confident claim about a branch the URL never named.
+  assert.equal(parseRepoInfo('/octo/demo/tree/main-v2/src', document).ref, '');
+
+  // The boundary does not break the case it exists to serve.
+  assert.equal(parseRepoInfo('/octo/demo/tree/main/src', document).ref, 'main');
+});
+
+test('the ref is found under a route wrapper this code has never seen', () => {
+  const document = pageWithPayload({
+    someFutureRouteName: { refInfo: { name: 'develop' } },
+  });
+  assert.equal(parseRepoInfo('/octo/demo/tree/develop', document).ref, 'develop');
+});
+
+test('an abbreviated SHA in the URL resolves to the full SHA the page states', () => {
+  const sha = 'ea91b33ca57ff0581b38e735cc108f831bccbdaa';
+  const document = pageWithPayload({
+    codeViewLayoutRoute: { refInfo: { name: sha } },
+  });
+  // GitHub expands the abbreviation in the payload, so neither the equality nor
+  // the `<ref>/` prefix test matches. The second assertion is the broken one:
+  // the previous resolver forwarded the raw path, so the API was asked for a ref
+  // called `ea91b33/tokio` and answered `ref_not_found`. The first was already
+  // correct there; answering the full SHA rather than the abbreviation is what
+  // puts both URLs on the same cache entry.
+  assert.equal(parseRepoInfo('/tokio-rs/tokio/tree/ea91b33', document).ref, sha);
+  assert.equal(parseRepoInfo('/tokio-rs/tokio/tree/ea91b33/tokio', document).ref, sha);
+  // The full SHA still works through the ordinary path.
+  assert.equal(parseRepoInfo(`/tokio-rs/tokio/tree/${sha}`, document).ref, sha);
+});
+
+test('the SHA expansion cannot resolve a branch name to a similar branch name', () => {
+  // The guard that makes the check above safe: matching a candidate that merely
+  // *starts with* the path would resolve `/tree/main` to `main-v2`. Only a hex
+  // abbreviation expanding to a full SHA qualifies. The answer is the path's own
+  // `main` — never the near miss, which is the whole point.
+  const nearMiss = pageWithPayload({
+    codeViewLayoutRoute: { refInfo: { name: 'main-v2' } },
+  });
+  assert.equal(parseRepoInfo('/octo/demo/tree/main', nearMiss).ref, 'main');
+
+  // `deadbee` is hex and abbreviation-shaped, but a 7-char candidate is a
+  // branch name, not an expansion of one — so no expansion happens and the path
+  // stands on its own.
+  const shortCandidate = pageWithPayload({
+    codeViewLayoutRoute: { refInfo: { name: 'deadbeef' } },
+  });
+  assert.equal(parseRepoInfo('/octo/demo/tree/deadbee', shortCandidate).ref, 'deadbee');
+});
+
+test('a single path segment is the ref, even when the page names something else', () => {
+  // `/owner/repo/tree/<x>` has exactly one segment after `tree`, and a folder
+  // cannot appear there without a ref in front of it — so `<x>` is a ref, and no
+  // agreement from the page is needed to say so. Nothing was broken here — the
+  // previous resolver returned the path too, by falling through to it. This rule
+  // is what keeps that answer now that an agreement check runs first: without it
+  // a contradicted page would reach `''`, and a URL naming a tag would report the
+  // default branch's count. It is a regression test, not a fix.
+  //
+  // The payload here names a *different* ref on purpose. That is what a soft
+  // navigation looks like mid-flight, and it is what a renamed wrapper looks
+  // like — the two failure modes this file exists to survive.
+  const stale = pageWithPayload({
+    codeViewLayoutRoute: { refInfo: { name: 'master' } },
+  });
+  assert.equal(parseRepoInfo('/octo/demo/tree/v1.2.3', stale).ref, 'v1.2.3');
+
+  // No payload at all: same reading, for the same reason.
+  const { document } = parseHTML(
+    '<html><body><div id="repository-container-header"></div></body></html>'
+  );
+  assert.equal(parseRepoInfo('/octo/demo/tree/v2.0.0', document).ref, 'v2.0.0');
+
+  // Two segments keep the old answer: `release/1.x` and `release` + `1.x` are
+  // the same URL, so with nothing on the page to break the tie there is no
+  // reading to prefer, and `''` (the default branch) is the documented guess.
+  assert.equal(parseRepoInfo('/octo/demo/tree/release/1.x', document).ref, '');
+});
+
+test('a repo home with no payload falls back to the default-branch meta tag', () => {
+  const { document } = parseHTML(`
+    <html><head>
+      <meta name="octolytics-dimension-repository_default_branch" content="trunk">
+    </head><body><div id="repository-container-header"></div></body></html>
+  `);
+  assert.equal(parseRepoInfo('/octo/demo', document).ref, 'trunk');
+});
+
+test('an unresolvable ref is reported as empty, which means "use the default branch"', () => {
+  // No payload and no meta on a tree view, and `master/app` is two segments, so
+  // the path cannot be read as a ref either (see the single-segment test above,
+  // which is the case where it can). `HEAD` was the old answer here, and
+  // `master/app` the one before that — both are claims this code cannot support.
+  const { document } = parseHTML('<html><body><div id="repository-container-header"></div></body></html>');
+  assert.equal(parseRepoInfo('/octo/demo/tree/master/app', document).ref, '');
+  assert.equal(parseRepoInfo('/octo/demo', document).ref, '');
+  // Not a repository route at all.
+  assert.equal(parseRepoInfo('/octo/demo/issues', document).ref, '');
+});
+
+test('the branch button is used when the payload has no ref', () => {
+  const { document } = parseHTML(`
+    <html><body>
+      <div id="repository-container-header"></div>
+      <summary data-hotkey="w"><span>master</span></summary>
+    </body></html>
+  `);
+  assert.equal(parseRepoInfo('/octo/demo/tree/master/app', document).ref, 'master');
 });
 
 /* ── diagnostics ─────────────────────────────────────────────────────────── */


### PR DESCRIPTION
## The bug

The SLOC card fails on any GitHub **folder** page. `detect.js` read `refInfo`
from only two places:

```js
const embeddedRef = payload?.codeViewRepoRoute?.refInfo?.name?.trim()
  || payload?.refInfo?.name?.trim()
  || '';
```

`codeViewRepoRoute` does not exist on a tree page — GitHub keeps `refInfo` under
the route wrapper for the page type it is rendering. Every other fallback is dead
there too (no branch button, no `octolytics-dimension-repository_default_branch`
meta tag), so `resolveRefFromPage` fell through to `return treePath || …` and
handed the API a **path**:

```
POST /api/analyze  { refName: "master/builtin" }   → ref_not_found
```

Nothing about this is specific to `master`; `/tree/main/axum-core` failed the same
way. What it is specific to is **depth** — one segment after `/tree/` worked, two
or more did not. So the extension worked right up until anyone clicked into a
folder, which is why it went unnoticed.

## The resolver, before and after

`extension/tests/fixtures/github-tree-view.html` is real markup captured from
`github.com/git/git/tree/master/builtin`. Running both resolvers over the same
inputs:

| page / path | before | after |
|---|---|---|
| fixture, `/git/git/tree/master/builtin` | `"master/builtin"` → **`ref_not_found`** | `"master"` |
| fixture, `/git/git/tree/master` | `"master"` | `"master"` |
| page states full SHA, `/tree/ea91b33/tokio` | `"ea91b33/tokio"` → **`ref_not_found`** | `"ea91b33ca57f…"` |
| page states full SHA, `/tree/ea91b33` | `"ea91b33"` | `"ea91b33ca57f…"` |
| page states `main`, `/tree/main-v2` | `"main"` → **wrong tree, no error** | `"main-v2"` |
| page states `master`, `/tree/v1.2.3` | `"v1.2.3"` | `"v1.2.3"` |
| live `github.com/git/git` repo home | `"master"` | `"master"` |

Two rows are the interesting ones and they fail in opposite ways. Rows 1 and 3
send a path as a ref and get a hard error. Row 5 is the quiet one: the old check
was a bare `treePath.startsWith(embeddedRef)`, so a page stating `main` matched a
path of `main-v2` and the card reported `main`'s count under a URL that named
`main-v2` — a real ref, resolvable, the wrong tree, and no sign anything went
wrong. The `/` in the new `` `${ref}/` `` prefix is what closes that.

## Where the ref is read from now

- `codeViewLayoutRoute` first, because it carries `refInfo` on every code-view
  page type, then the older wrappers, then a bounded structural walk for any
  `refInfo` key so the next rename degrades rather than breaks. The branch button
  and the meta tag stay where they were, at the end.
- The resolver splits on whether there is a tree path at all, so precedence is not
  one flat list. On a repo home the page is the only source: payload ref, else
  button, else meta tag. On a tree view the meta tag is **not** consulted — it
  names the *default* branch, which is the one thing a `/tree/…` URL is saying it
  is not looking at.
- On a tree view the path is used to *choose between* the refs the page states,
  not as a ref. `/tree/feature/name` and `/tree/<ref>/<folder>` are the same URL
  shape, so the ref that equals the path, or is a `<ref>/` prefix of it, is the
  one being viewed. Nothing else can be.
- **One segment after `/tree/` is a regression test, not a fix.** A folder cannot
  appear there without a ref in front of it, so `/tree/v1.2.3` is `v1.2.3` whether
  or not the page agrees — which is also what the old fall-through returned. The
  rule exists so that adding the agreement check above does not lose it.
- **Two or more segments with nothing on the page agreeing** is genuinely
  ambiguous (`release/1.x` versus `release` plus `1.x`) and nothing in the URL
  distinguishes them. There the answer is `''`, omitted from the request, so the
  API resolves the default branch. Claiming a split GitHub never confirmed would
  be worse: it invents a ref, and it is unstable across a soft navigation.
- `/tree/ea91b33/tokio` needs its own rule, because GitHub expands the
  abbreviation in the payload — the stated ref neither equals the path nor
  prefixes it, so the ambiguous-path branch would answer `''`, i.e. the default
  branch's count for a URL pinned to a commit. A hex abbreviation is matched
  against a full SHA the page states, and the expansion is returned.
  `/tree/ea91b33` on its own was never broken; it goes through the same rule only
  so both URLs land on one cache entry per commit. The check stays scoped to that
  shape deliberately: a bare *reverse* `startsWith` would resolve `/tree/main` to
  a branch named `main-v2`.

## `HEAD` → `''`

The last-resort value changes. Both mean "let the API pick the default branch" —
`cacheKey`/`inflightKey` already fall back to `HEAD`, and `analyze()` now omits an
empty ref from the request body — but `''` is the value the ambiguous-path case
needs, and one spelling of "unknown" is worth more than keeping the old one.

`getRepoVisibility` is untouched and still tri-state; nothing here changes what
decides whether owner/repo is sent to the API.

## Errors

`ref_not_found` and `invalid_url` join `NON_RETRYABLE` and get a message in all
five locales. `invalid_url` had neither, and there is no second line of defence
for that: `classifyError` returns `{ code, status, detail }` and drops the API's
`message`, so the `error?.message` term in `errorMessage` is always `undefined`.
An unmapped code renders as "Analysis failed", and being non-retryable it renders
with no retry button — no explanation and no action.

`not_found` is deliberately **left retryable** even though it sounds terminal. The
API returns it for the archive download 404ing as well as for a missing
repository; the backend retries 5xx and 429 but never a 404; and this card only
runs on a page GitHub has already served as a public repo. On this surface a 404
is far more likely transient than real. There is a comment in `card.js` saying so,
because the next person to read that set will assume it was an oversight.

## Tests

`extension/tests/github-dom.test.mjs`: **24 → 35**, none removed or renamed.

The anchor is the captured fixture, on the exact route that was broken. The other
ten build payloads inline, because the shapes they pin cannot all appear on one
page: the older wrappers GitHub still serves on unmigrated pages, a wrapper name
that does not exist yet, slashed refs, abbreviated SHAs.

Both rules that can silently return a *wrong* ref rather than no ref are pinned by
a test that fails if the rule is relaxed — checked by mutating the source, not
assumed:

| mutation | result |
|---|---|
| `` `${ref}/` `` → `ref` in the agreement check | 1 failure: `a stated ref is only believed at a segment boundary` |
| drop `FULL_SHA.test(ref)` from `expandedShaFor` | 1 failure: `the SHA expansion cannot resolve a branch name to a similar branch name` |

Nothing else moves in either case, which is the property worth having.

`npm test` on this branch: 35/35 unit, chrome + edge + firefox builds, 8/8
`build-artifacts`.

The fixture is real markup rather than a synthetic payload because it is the one
thing that can testify the wrapper names are right *today*: it shows `refInfo`
under `codeViewLayoutRoute` and `codeViewTreeRoute`, no `codeViewRepoRoute` at
all, and no default-branch meta tag — so on this route the payload is the only
place a ref can come from, with nothing left to fall back on. It is trimmed
(tokens, the ~140-entry file tree, feature flags, SVG noise) and the trimming is
recorded in the file's own header comment; nothing that remains was edited.

## One note on the fixture, to save you a false lead

The fixture is a capture of a *tree* page, so feeding it a repo-home path makes
the old resolver bottom out at `HEAD`. That is an artefact of replaying the wrong
page shape, not a bug being demonstrated — a live fetch of `github.com/git/git`
does carry `codeViewRepoRoute.refInfo.name` (and `codeViewLayoutRoute`'s, same
value), so the old resolver already answered `master` on repo homes and the new
one still does: same request, same cache key, same `master → sha` in the panel.
That is row 7 of the table above.

`parseRepoInfo` and `detectFork` now take the pathname and root they read, so the
ref tests can drive them without a global document.
